### PR TITLE
Remove fly services

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,29 +10,3 @@ processes = []
 [experimental]
   allowed_public_ports = []
   auto_rollback = true
-
-[[services]]
-  http_checks = []
-  internal_port = 8080
-  processes = ["app"]
-  protocol = "tcp"
-  script_checks = []
-  [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
-    type = "connections"
-
-  [[services.ports]]
-    force_https = true
-    handlers = ["http"]
-    port = 80
-
-  [[services.ports]]
-    handlers = ["tls", "http"]
-    port = 443
-
-  [[services.tcp_checks]]
-    grace_period = "1s"
-    interval = "15s"
-    restart_limit = 0
-    timeout = "2s"


### PR DESCRIPTION
Lumafly does not expose any ports and endpoints, and does not serve any content. Disabling services in fly so that fly does not use them to run unnecessary health checks